### PR TITLE
Fix Monte Carlo simulation in option pricing models

### DIFF
--- a/option_pricing/MonteCarloSimulation.py
+++ b/option_pricing/MonteCarloSimulation.py
@@ -90,3 +90,27 @@ class MonteCarloPricing(OptionPricingModel):
         plt.title(f'First {num_of_movements}/{self.N} Random Price Movements')
         plt.legend(loc='best')
         plt.show()
+
+    def get_calculation_steps(self):
+        """
+        Returns a dictionary containing input parameters, intermediate calculations, and final calculations.
+        """
+        steps = {
+            "Input Parameters": {
+                "Spot Price": self.S_0,
+                "Strike Price": self.K,
+                "Time to Maturity (days)": self.T * 365,
+                "Risk-free Rate": self.r,
+                "Volatility": self.sigma,
+                "Number of Simulations": self.N
+            },
+            "Intermediate Calculations": {
+                "Time Step (dt)": self.dt,
+                "Simulated Prices": self.simulation_results_S
+            },
+            "Final Calculations": {
+                "Call Option Price": self._calculate_call_option_price(),
+                "Put Option Price": self._calculate_put_option_price()
+            }
+        }
+        return steps

--- a/option_pricing_test.py
+++ b/option_pricing_test.py
@@ -31,4 +31,23 @@ print(MC.calculate_option_price('Call Option'))
 print(MC.calculate_option_price('Put Option'))
 MC.plot_simulation_results(20)
 
+# Test cases for get_calculation_steps method in MonteCarloPricing class
+calculation_steps = MC.get_calculation_steps()
+print("Calculation Steps:")
+print(calculation_steps)
 
+# Verify input parameters
+assert calculation_steps["Input Parameters"]["Spot Price"] == 100
+assert calculation_steps["Input Parameters"]["Strike Price"] == 100
+assert calculation_steps["Input Parameters"]["Time to Maturity (days)"] == 365
+assert calculation_steps["Input Parameters"]["Risk-free Rate"] == 0.1
+assert calculation_steps["Input Parameters"]["Volatility"] == 0.2
+assert calculation_steps["Input Parameters"]["Number of Simulations"] == 10000
+
+# Verify intermediate calculations
+assert calculation_steps["Intermediate Calculations"]["Time Step (dt)"] == MC.dt
+assert calculation_steps["Intermediate Calculations"]["Simulated Prices"] is not None
+
+# Verify final calculations
+assert calculation_steps["Final Calculations"]["Call Option Price"] == MC.calculate_option_price('Call Option')
+assert calculation_steps["Final Calculations"]["Put Option Price"] == MC.calculate_option_price('Put Option')

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -174,6 +174,12 @@ elif pricing_method == OPTION_PRICING_MODEL.MONTE_CARLO.value:
 
                 st.subheader(f'Call option price: {call_option_price:.2f}')
                 st.subheader(f'Put option price: {put_option_price:.2f}')
+
+                # Display calculation steps
+                calculation_steps = MC.get_calculation_steps()
+                st.subheader("Calculation Steps")
+                st.json(calculation_steps)
+
             else:
                 st.error("Unable to proceed with calculations due to data fetching error.")
         except Exception as e:


### PR DESCRIPTION
added method get_calculation_steps to return intermediate and final calculation steps.
added test cases to verify this method.
added a section to display the calculation steps for the simulation

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/just-krivi/option-pricing-models/pull/14?shareId=36a007fb-2540-46f0-bfa9-1ef4481f122d).